### PR TITLE
Yml is not always a dict

### DIFF
--- a/tests/test_yamldown.py
+++ b/tests/test_yamldown.py
@@ -109,6 +109,14 @@ class TestLoad(unittest.TestCase):
         self.assertEqual(yml_contents, expected_yml)
         self.assertEqual(md_contents, expected_md)
 
+    def test_return_empty_dict_when_no_yaml(self):
+        doc = string_document(just_md())
+        yml_contents, md_contents = yamldown._load(doc)
+
+        expected_yml = {}
+
+        self.assertEqual(yml_contents, expected_yml)
+
 class TestDump(unittest.TestCase):
 
     def test_dump_yaml_first(self):

--- a/yamldown/yamldown.py
+++ b/yamldown/yamldown.py
@@ -31,7 +31,7 @@ def _load(stream: IO[str]) -> Tuple[Dict, str]:
 
         current_buffer.append(line)
 
-    yml_dict = yaml.load(yml_contents.contents, Loader=yaml.FullLoader) # type: Dict
+    yml_dict = yaml.load(yml_contents.contents, Loader=yaml.FullLoader) or {} # type: Dict
     return (yml_dict, md_contents.contents.strip("\n"))
 
 def _is_yaml_start(line: str, yml_buffer: Buffer) -> bool:


### PR DESCRIPTION
In markdown documents that don't have yml frontmatter, the `yml_contents` returns `None` instead of the expected `Dict`.

I added a way to ensure it returns a dict, but I'm open to discussing how to do that.